### PR TITLE
Fix fw_current_url() server name bug

### DIFF
--- a/framework/helpers/general.php
+++ b/framework/helpers/general.php
@@ -1316,8 +1316,11 @@ function fw_current_url() {
 
 	if ( $url === null ) {
 		$url = 'http://';
-
-		if ( $_SERVER['SERVER_NAME'] === '_' ) { // https://github.com/ThemeFuse/Unyson/issues/126
+		
+        	//https://github.com/ThemeFuse/Unyson/issues/2442
+		$server_wildcard_or_regex = preg_match('/(^~\^|^\*\.|\.\*$)/', $_SERVER['SERVER_NAME']);
+		
+		if ( $_SERVER['SERVER_NAME'] === '_' || 1 === $server_wildcard_or_regex ) ) { // https://github.com/ThemeFuse/Unyson/issues/126
 			$url .= $_SERVER['HTTP_HOST'];
 		} else {
 			$url .= $_SERVER['SERVER_NAME'];


### PR DESCRIPTION
fixes #2442
Using regex to determine if `SERVER_NAME` is valid url.

regex test:
https://regex101.com/r/ty0Pzg/1