### PR TITLE
Fix rgba opacity slider not going all the way down to zero

### DIFF
--- a/framework/includes/option-types/rgba-color-picker/static/js/scripts.js
+++ b/framework/includes/option-types/rgba-color-picker/static/js/scripts.js
@@ -8,7 +8,7 @@ jQuery(function($){
   };
   Color.prototype.toRgba = function (a) {
     var rgb = this.toRgb();
-    rgb['a'] = a || 1
+    rgb['a'] = (typeof a === 'undefined') ? 1 : 0;
     return rgb;
   }
   Color.prototype.toRgbaCSS = function (a) {


### PR DESCRIPTION
`0` is falsy that's why the slider couldn't go all the way to zero (snaps back to `1`)
closes #2781